### PR TITLE
Adds `/v1/names/` response for pending names

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "A subdomain registrar for Blockstack",
   "main": "lib/index.js",
   "dependencies": {
+    "bitcoinjs-lib": "^3.3.2",
     "blockstack": "^0.16.0",
     "cors": "^2.8.4",
     "express": "^4.16.2",
     "node-fetch": "^2.0.0",
+    "ripemd160": "^2.0.1",
     "rwlock": "^5.0.0",
     "sqlite3": "^3.1.13",
     "winston": "^2.4.0",

--- a/src/db.js
+++ b/src/db.js
@@ -190,7 +190,7 @@ export class RegistrarQueueDB {
   }
 
   getStatusRecord(subdomainName) {
-    const lookup = 'SELECT status, status_more FROM subdomain_queue' +
+    const lookup = 'SELECT status, status_more, owner, zonefile FROM subdomain_queue' +
           ' WHERE subdomainName = ? ORDER BY queue_ix DESC LIMIT 1'
     return dbAll(this.db, lookup, [subdomainName])
   }

--- a/src/http.js
+++ b/src/http.js
@@ -127,6 +127,21 @@ export function makeHTTPServer(config) {
       })
   })
 
+  app.get('/v1/names/:fullyQualified', (req, res) => {
+    server.getSubdomainInfo(req.params.fullyQualified)
+      .catch(error => {
+        logger.error(error)
+        return { message: { error: 'Error processing request' },
+                 statusCode: 400 }
+      })
+      .then(infoResponse => {
+        res.writeHead(infoResponse.statusCode, HEADERS)
+        res.write(JSON.stringify(
+          infoResponse.message))
+        res.end()
+      })
+  })
+
   const zonefileDelay = Math.min(2147483647,
                                  Math.floor(60000 * config.checkTransactionPeriod))
   const batchDelay = Math.min(2147483647,

--- a/src/lookups.js
+++ b/src/lookups.js
@@ -5,7 +5,7 @@ import logger from 'winston'
 export function isSubdomainRegistered(fullyQualifiedAddress: String) {
   return new Promise((resolve, reject) => {
     bskConfig.network.getNameInfo(fullyQualifiedAddress)
-      .then(() => resolve(true))
+      .then(nameInfo => resolve(nameInfo.status === 'registered_subdomain'))
       .catch((err) => {
         if (err.message === 'Name not found') {
           resolve(false)

--- a/src/operations.js
+++ b/src/operations.js
@@ -2,6 +2,8 @@ import { transactions, config as bskConfig, safety, hexStringToECPair } from 'bl
 import { makeZoneFile } from 'zone-file'
 import logger from 'winston'
 import fetch from 'node-fetch'
+import { crypto } from 'bitcoinjs-lib'
+import RIPEMD160 from 'ripemd160'
 
 export type SubdomainOp = {
   owner: String,
@@ -128,6 +130,11 @@ Promise<Array<{txHash: String, status: Boolean}>> {
           })
       ))
     )
+}
+
+export function hash160(input: Buffer) {
+  const sha256 = crypto.sha256(input)
+  return (new RIPEMD160()).update(sha256).digest()
 }
 
 // this is a hack -- this is a stand-in while we roll out support for

--- a/tests/src/unitTestLookups.js
+++ b/tests/src/unitTestLookups.js
@@ -13,7 +13,7 @@ export function unitTestLookups() {
 
     nock('https://core.blockstack.org')
       .get('/v1/names/foo.bar.id')
-      .reply(200, {})
+      .reply(200, { status: 'registered_subdomain'})
 
     isSubdomainRegistered('foo.bar.id')
       .then(x => t.ok(x))
@@ -66,7 +66,7 @@ export function unitTestLookups() {
     nock.cleanAll()
     nock('https://core.blockstack.org')
       .get('/v1/names/foo.bar.id')
-      .reply(200, {})
+      .reply(200, { status: 'registered_subdomain'})
 
     nock('https://core.blockstack.org')
       .get('/v1/names/bar.bar.id')

--- a/tests/src/unitTestServer.js
+++ b/tests/src/unitTestServer.js
@@ -11,7 +11,7 @@ const testSK = 'c14b3044ca7f31fc68d8fcced6b60effd350c280e7aa5c4384c6ef32c0cb129f
 export function testSubdomainServer() {
 
   test('queueRegistration', (t) => {
-    t.plan(10)
+    t.plan(14)
     nock.cleanAll()
 
     nock('https://core.blockstack.org')
@@ -101,8 +101,21 @@ export function testSubdomainServer() {
           s.getSubdomainStatus('tar')
           .then((x) =>
                 t.ok(x.status.startsWith('Subdomain not registered', 'tar.bar.id should not be queued'))))
-
-    })
+      .then(
+        () =>
+          s.getSubdomainInfo('bar.bar.id')
+          .then(resp =>
+                {
+                  t.equal(resp.message.status, 'submitted_subdomain')
+                  t.equal(resp.message.address, testAddress)
+                  t.equal(resp.message.last_txid, 'txhash')
+                }))
+      .then(
+        () =>
+          s.getSubdomainInfo('tar.bar.id')
+          .then(resp => t.equal(resp.statusCode, 404)))
+      .catch( (err) => { console.log(err.stack) } )
+  })
 
   test('apiKeyOnly', (t) => {
     t.plan(2)

--- a/tests/src/unitTestServer.js
+++ b/tests/src/unitTestServer.js
@@ -17,7 +17,7 @@ export function testSubdomainServer() {
     nock('https://core.blockstack.org')
       .persist()
       .get('/v1/names/foo.bar.id')
-      .reply(200, {})
+      .reply(200, { status: 'registered_subdomain'})
 
     nock('https://core.blockstack.org')
       .persist()
@@ -81,7 +81,7 @@ export function testSubdomainServer() {
         () =>
           s.getSubdomainStatus('bar')
           .then((x) =>
-                t.ok(x.status.startsWith('Subdomain is queued for update', 'bar.bar.id should be queued'))))
+                t.ok(x.status.startsWith('Subdomain is queued for update'), 'bar.bar.id should be queued')))
       .then(
         () =>
           s.updateQueueStatus(['bar'], 'txhash'))
@@ -207,7 +207,7 @@ export function testSubdomainServer() {
         nock('https://core.blockstack.org')
           .get('/v1/names/foo.bar.id')
           .times(1)
-          .reply(200, {})
+          .reply(200, { status: 'registered_subdomain'})
       })
       .then(() => s.lock.writeLock((release) => {
         s.submitBatch()


### PR DESCRIPTION
Addresses #7 --- when a name is pending (a batch containing the name isn't issued yet) or the batch has been submitted, but not picked up by indexers yet, the registrar will respond to `/v1/names/` lookups.

For pending names, the `status` will be `"pending_subdomain"` and `last_txid` will be an empty string. For submitted names, the `status` will be `"submitted_subdomain"` and `last_txid` will be the txid it was submitted in.

Examples:

```javascript
$ curl -q localhost:3000/v1/names/potato.testing_test.id | jq .
{
  "blockchain": "bitcoin",
  "status": "pending_subdomain",
  "last_txid": "",
  "zonefile": "$ORIGIN potato.testing_test.id\n$TTL 3600\n_https._tcp URI 10 1 \"https://gaia.blockstack.org/hub/1PQs1WF5BPDM7bT85z2TBaLCofsnGBEatb/profile.json\"\n",
  "address": "1PQs1WF5BPDM7bT85z2TBaLCofsnGBEatb",
  "zonefile_hash": "81637262dfde7bbf774ccb60964c02a610acac18"
}

$ curl -q localhost:3000/v1/names/aaron.testing_test.id | jq .
{
  "address": "16LPutBwZQXy9BypANh1q2y5Z5fpwrmifp",
  "blockchain": "bitcoin",
  "last_txid": "ca18e86b06660db934a697ed417e650988ba4a9da4296d155d55909400dda3fb",
  "status": "submitted_subdomain",
  "zonefile": "$ORIGIN aaron.blockstack_berlin.id\n$TTL 3600\n_https._tcp URI 10 1 \"https://gaia.blockstack.org/hub/16LPutBwZQXy9BypANh1q2y5Z5fpwrmifp/profile.json\"\n",
  "zonefile_hash": "320d7c7cc5c0be10da74a9eb487e4c216982118a"
}
```