### PR TITLE
Support for whitelisting IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ In order to support registration requests from "trusted sources", you can use th
 to add an array of allowed api keys. Requests with an `Authorization: bearer <apiKey>` header will then be able to
 skip the spam countermeasures.
 
+### Whitelisting IP Addresses
+
+If you add a key to your `config.json` file, you can whitelist IPs against your spam counter measures, e.g.:
+
+```
+{
+  ...
+  "ipWhitelist": ["127.0.0.1"],
+  ...
+}
+```
+
 ### Private Key Storage
 
 You can either store your private key hexes in your config.json, or pass them

--- a/config-sample.json
+++ b/config-sample.json
@@ -8,6 +8,7 @@
   "port": 3000,
   "disableRegistrationsWithoutKey": false,
   "apiKeys": ["6b22b2c7-8258-4ff9-8ff1-19f1f9f0148a"],
+  "ipWhitelist": ["127.0.0.1"],
   "winstonConsoleTransport": {
       "level": "info",
       "handleExceptions": false,


### PR DESCRIPTION
This adds support for whitelisting IP addresses.

If you add the key `ipWhitelist` to the config.json, you can create a list of IP addresses that get whitelisted from the IP-limiting spam counter-measure.

