### PR TITLE
adding ADMIN_PASSWORD env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ $ which blockstack-subdomain-registrar
 
 The subdomain registrar functions roughly as follows --- you give the registrar a _domain_ to register subdomains under, you fund a wallet to submit registrations with, it accepts registration requests, and then it periodically issues _batches_ of name registrations. 
 
+### Setting the Admin Password
+1. Set the `ADMIN_PASSWORD` environment var to strong password. 
+ex: 
+```bash
+$ pwgen -c 64 1
+raj5gohhai0ni3bah4chaa6keeCh4Oophongaikeichie2eirah8AjooyahZaifi
+```
+
 ### Setting the Domain Name
 
 For example, if I want to register names like `alice.people.id` or `bob.people.id`, I have to:

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import { PAYER_SK, OWNER_SK, DEVELOP_DOMAIN } from './developmode'
+import { PAYER_SK, OWNER_SK, DEVELOP_DOMAIN, ADMIN_PASSWORD } from './developmode'
 import winston from 'winston'
 import fs from 'fs'
 
@@ -17,7 +17,7 @@ const configDevelopDefaults = {
   batchDelayPeriod: 0.5,
   checkTransactionPeriod: 0.1,
   dbLocation: '/tmp/subdomain_registrar.db',
-  adminPassword: 'tester129',
+  adminPassword: ADMIN_PASSWORD,
   domainUri: 'file:///tmp/whatever',
   resolverUri: 'http://localhost:3000',
   zonefileSize: 40960,
@@ -50,7 +50,7 @@ const configDefaults = {
   checkTransactionPeriod: 5,
   zonefileSize: 40960,
   dbLocation: 'subdomain_registrar.db',
-  adminPassword: 'NEEDS-A-PASSWORD',
+  adminPassword: null,
   domainUri: 'https://registrar.whatever.com',
   resolverUri: false,
   port: 3000,
@@ -89,7 +89,9 @@ export function getConfig() {
   if (process.env.BSK_SUBDOMAIN_OWNER_KEY) {
     config.ownerKey = process.env.BSK_SUBDOMAIN_OWNER_KEY
   }
-
+  if (process.env.ADMIN_PASSWORD) {
+    config.ownerKey = process.env.ADMIN_PASSWORD || configDevelopDefaults.ADMIN_PASSWORD
+  }
   if (process.env.BSK_SUBDOMAIN_PROMETHEUS_PORT) {
     config.prometheus = { start: true, port: parseInt(process.env.BSK_SUBDOMAIN_PROMETHEUS_PORT) }
   }

--- a/src/developmode.js
+++ b/src/developmode.js
@@ -6,6 +6,7 @@ import { StacksMocknet } from '@stacks/network'
 export const PAYER_SK = 'bb68eda988e768132bc6c7ca73a87fb9b0918e9a38d3618b74099be25f7cab7d01'
 export const OWNER_SK = '8f87d1ea26d03259371675ea3bd31231b67c5df0012c205c154764a124f5b8fe01'
 export const DEVELOP_DOMAIN = 'foo.id'
+export const ADMIN_PASSWORD = 'tester129'
 
 function pExec(cmd) {
   return new Promise(


### PR DESCRIPTION

## Description
Adds a new env var `ADMIN_PASSWORD` so it doesn't have to be hard-coded in the config file as `adminPassword: xxxxx`




For details refer to issue #47 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] API reference/documentation update
- [ ] Other





